### PR TITLE
remove NewObjectId() in return

### DIFF
--- a/clients/mongo-client.go
+++ b/clients/mongo-client.go
@@ -114,7 +114,7 @@ func (mc *MongoClient) AddEvent(e *models.Event) (bson.ObjectId, error) {
 	// Add the event
 	err := s.DB(mc.Database.Name).C(EVENTS_COLLECTION).Insert(me)
 	if err != nil {
-		return bson.NewObjectId(), err
+		return e.ID, err
 	}
 
 	return e.ID, err
@@ -456,12 +456,12 @@ func (mc *MongoClient) AddValueDescriptor(v models.ValueDescriptor) (bson.Object
 	// See if the name is unique
 	count, err := s.DB(mc.Database.Name).C(VALUE_DESCRIPTOR_COLLECTION).Find(bson.M{"name": v.Name}).Count()
 	if err != nil {
-		return bson.NewObjectId(), err
+		return v.Id, err
 	}
 
 	// Duplicate name
 	if count > 0 {
-		return bson.NewObjectId(), ErrNotUnique
+		return v.Id, ErrNotUnique
 	}
 
 	// Created/Modified now


### PR DESCRIPTION
Signed-off-by: Masataka Mizukoshi <m.mizukoshi.wakuwaku@gmail.com>
``bson.NewObjectId()`` is not necessary when return values.